### PR TITLE
Fix args option

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,8 @@ module.exports = function (opts) {
   opts.quality = opts.quality || 75
   var args = []
   if (opts.quality) args.push('-quality', opts.quality)
-  if (opts.args) args.push(opts.args.split[' '])
-
-  var foo = dcp.spawn(mozjpeg, args)
-  return foo
+  if (opts.args) {
+    args = args.concat(opts.args.split(' '))
+  }
+  return dcp.spawn(mozjpeg, args)
 }


### PR DESCRIPTION
Passing args through causes a crash, e.g.:

```
readStream
  .pipe(mozjpeg({quality: 90, args: '-baseline'}))
  .pipe(writeStream);
```

results in:

```
events.js:141
      throw er; // Unhandled 'error' event
      ^

Error: Command failed: <snip>/node_modules/mozjpeg/vendor/cjpeg: can't open undefined

    at ChildProcess.onExit (<snip>/node_modules/duplex-child-process/index.js:116:12)
    at ChildProcess.g (events.js:260:16)
    at emitTwo (events.js:87:13)
    at ChildProcess.emit (events.js:172:7)
    at maybeClose (internal/child_process.js:818:16)
    at Socket.<anonymous> (internal/child_process.js:319:11)
    at emitOne (events.js:77:13)
    at Socket.emit (events.js:169:7)
    at Pipe._onclose (net.js:469:12)
```

This makes it work :wink: 
