### PR TITLE
Move tape to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,14 +10,14 @@
   "license": "ISC",
   "dependencies": {
     "duplex-child-process": "0.0.5",
-    "mozjpeg": "^4.0.1",
-    "tape": "^4.0.0"
+    "mozjpeg": "^4.0.1"
   },
   "devDependencies": {
     "buffer-equal": "0.0.1",
     "concat-stream": "^1.5.0",
     "standard": "^4.5.2",
-    "stream-to-buffer": "^0.1.0"
+    "stream-to-buffer": "^0.1.0",
+    "tape": "^4.0.0"
   },
   "directories": {
     "test": "test"


### PR DESCRIPTION
I see that `tape` is used only for testing (not surprising), so I think it should be in the `devDependencies` section of the package.json file.
